### PR TITLE
Restore Telegram bot core functionality

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,12 +15,17 @@ ANTHROPIC_API_KEY = os.environ.get('ANTHROPIC_API_KEY')
 
 import httpx
 
-# Создаем клиент с явными настройками
-client = anthropic.Anthropic(
-    api_key=ANTHROPIC_API_KEY,
-    max_retries=2,
-    timeout=httpx.Timeout(60.0, connect=10.0)
-)
+# Создаем клиент с явными настройками (если доступен ключ)
+if ANTHROPIC_API_KEY:
+    client = anthropic.Anthropic(
+        api_key=ANTHROPIC_API_KEY,
+        max_retries=2,
+        timeout=httpx.Timeout(60.0, connect=10.0)
+    )
+else:
+    client = None
+
+DEFAULT_MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
 
 class SessionState(Enum):
     WAITING_TASK = "waiting_task"
@@ -321,25 +326,7 @@ async def button_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await query.message.reply_text(f"💡 {response}")
 
 async def show_statistics(query, session):
-    stats = session.stats
-    
-    if stats["total_tasks"] == 0:
-        text = "📊 Статистика пока пуста.\n\nРеши несколько задач, чтобы увидеть свой прогресс!"
-    else:
-        text = f"""📊 ТВОЯ СТАТИСТИКА
-
-✅ Решено задач: {stats['completed_tasks']}/{stats['total_tasks']}
-⭐ Средний балл: {stats['average_score']:.1f}/100
-💡 Использовано подсказок: {stats['total_hints']}
-🎭 Заработано мемов: {stats.get('total_memes_earned', 0)}
-📈 Процент успеха: {(stats['completed_tasks']/stats['total_tasks']*100):.1f}%
-
-📚 Последние задачи:"""
-        
-        for task in stats['tasks_history'][-5:]:
-            emoji = "✅" if task['score'] >= 70 else "⚠️" if task['score'] >= 50 else "❌"
-            text += f"\n{emoji} {task['date']}: {task['score']}/100"
-    
+    text = build_statistics_text(session)
     keyboard = [[InlineKeyboardButton("🔙 Назад", callback_data="start_solving")]]
     await query.edit_message_text(text, reply_markup=InlineKeyboardMarkup(keyboard))
 
@@ -474,25 +461,29 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
 
 async def recognize_math_from_image(image_base64):
+    if not client:
+        return None
+
     try:
-        message = client.messages.create(
-            model="claude-sonnet-4-20250514",
-            max_tokens=1024,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": "image/jpeg",
-                                "data": image_base64,
+        def _request():
+            return client.messages.create(
+                model="claude-sonnet-4-20250514",
+                max_tokens=1024,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/jpeg",
+                                    "data": image_base64,
+                                },
                             },
-                        },
-                        {
-                            "type": "text",
-                            "text": """Распознай математическую задачу с этого изображения.
+                            {
+                                "type": "text",
+                                "text": """Распознай математическую задачу с этого изображения.
 
 ИНСТРУКЦИИ:
 1. Извлеки ТОЛЬКО текст задачи (условие, вопрос)
@@ -512,8 +503,10 @@ async def recognize_math_from_image(image_base64):
                     ],
                 }
             ],
-        )
-        
+            )
+
+        message = await asyncio.to_thread(_request)
+
         recognized_text = message.content[0].text.strip()
         
         if "НЕТ ЗАДАЧИ" in recognized_text.upper():
@@ -642,8 +635,242 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         
         if session.meme_enabled:
             session.stats["total_memes_earned"] = session.stats.get("total_memes_earned", 0) + 1
-            
+
             await update.message.chat.send_action("typing")
             await asyncio.sleep(1)
-            
+
             meme_emoji = "🎯" if new_score >= 80 else "🙂" if new_score >= 60 else "😢"
+            meme_text = await generate_meme_text(new_score, session.current_task, session.difficulty)
+            if meme_text:
+                await update.message.reply_text(f"{meme_emoji} {meme_text}")
+
+        # Сбрасываем состояние после завершения задачи
+        session.current_task = None
+        session.conversation = []
+        session.task_start_time = None
+        session.state = SessionState.WAITING_TASK
+
+
+def build_statistics_text(session: UserSession) -> str:
+    stats = session.stats
+
+    if stats["total_tasks"] == 0:
+        return "📊 Статистика пока пуста.\n\nРеши несколько задач, чтобы увидеть свой прогресс!"
+
+    success_rate = (stats["completed_tasks"] / stats["total_tasks"] * 100) if stats["total_tasks"] else 0
+
+    text = (
+        "📊 ТВОЯ СТАТИСТИКА\n\n"
+        f"✅ Решено задач: {stats['completed_tasks']}/{stats['total_tasks']}\n"
+        f"⭐ Средний балл: {stats['average_score']:.1f}/100\n"
+        f"💡 Использовано подсказок: {stats['total_hints']}\n"
+        f"🎭 Заработано мемов: {stats.get('total_memes_earned', 0)}\n"
+        f"📈 Процент успеха: {success_rate:.1f}%\n\n"
+        "📚 Последние задачи:"
+    )
+
+    if stats["tasks_history"]:
+        for task in stats["tasks_history"][-5:]:
+            emoji = "✅" if task["score"] >= 70 else "⚠️" if task["score"] >= 50 else "❌"
+            text += f"\n{emoji} {task['date']}: {task['score']}/100"
+    else:
+        text += "\n— пока нет завершенных задач"
+
+    return text
+
+
+async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    session = get_session(update.effective_user.id)
+    session.state = SessionState.WAITING_TASK
+    session.current_task = None
+    session.conversation = []
+    session.task_start_time = None
+
+    await update.message.reply_text(
+        "🔄 Начнем заново! Отправь новую математическую задачу или фото."
+    )
+
+
+async def submit_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    session = get_session(update.effective_user.id)
+
+    if session.state != SessionState.SOLVING:
+        await update.message.reply_text("Сначала отправь задачу и начни решение.")
+        return
+
+    session.state = SessionState.FINAL_ANSWER
+    await update.message.reply_text(
+        "✍️ Отлично! Теперь напиши свой ФИНАЛЬНЫЙ ОТВЕТ на задачу.\n\n"
+        "Постарайся расписать полный ход решения."
+    )
+
+
+async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    session = get_session(update.effective_user.id)
+    text = build_statistics_text(session)
+    await update.message.reply_text(text)
+
+
+async def hint_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    session = get_session(update.effective_user.id)
+
+    if session.state != SessionState.SOLVING:
+        await update.message.reply_text("Подсказки доступны только во время решения задачи.")
+        return
+
+    session.stats["total_hints"] += 1
+    session.conversation.append({
+        "role": "user",
+        "content": "Мне нужна подсказка. Дай небольшую подсказку, но не решение."
+    })
+
+    await update.message.chat.send_action("typing")
+    response = await get_ai_response(session, SYSTEM_PROMPT)
+    await update.message.reply_text(f"💡 {response}")
+
+
+async def call_claude(messages, system_prompt: str, max_tokens: int = 600) -> str:
+    if not client:
+        raise RuntimeError("Anthropic client is not configured")
+
+    def _request():
+        response = client.messages.create(
+            model=DEFAULT_MODEL,
+            system=system_prompt,
+            messages=messages,
+            max_tokens=max_tokens,
+        )
+
+        parts = []
+        for block in getattr(response, "content", []) or []:
+            text = getattr(block, "text", None)
+            if text is not None:
+                parts.append(text)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts).strip()
+
+    return await asyncio.to_thread(_request)
+
+
+async def get_ai_response(session: UserSession, system_prompt: str) -> str:
+    # Преобразуем историю в формат Anthropic
+    messages = []
+    for turn in session.conversation:
+        messages.append({
+            "role": turn["role"],
+            "content": [{"type": "text", "text": turn["content"]}]
+        })
+
+    try:
+        if client:
+            reply = await call_claude(messages, system_prompt)
+        else:
+            raise RuntimeError("Anthropic client unavailable")
+    except Exception:
+        # Фолбэк, чтобы бот продолжал работать даже без LLM
+        reply = (
+            "Давай подумаем вместе. Попробуй описать следующий шаг решения."
+            if session.state == SessionState.SOLVING
+            else "Расскажи подробнее, что именно тебя интересует в задаче."
+        )
+
+    session.conversation.append({"role": "assistant", "content": reply})
+    return reply
+
+
+async def verify_solution(task_text: str, student_answer: str) -> dict:
+    prompt = VERIFICATION_PROMPT.format(
+        original_task=task_text,
+        student_answer=student_answer
+    )
+
+    if client:
+        messages = [{
+            "role": "user",
+            "content": [{"type": "text", "text": prompt}]
+        }]
+        try:
+            response = await call_claude(messages, "Ты строгий, но справедливый проверяющий.")
+            data = json.loads(response)
+            # Гарантируем обязательные поля
+            return {
+                "correct": bool(data.get("correct", False)),
+                "final_answer": data.get("final_answer", "Не удалось определить"),
+                "score": int(data.get("score", 0)),
+                "feedback": data.get("feedback", "Нет обратной связи"),
+                "mistakes": data.get("mistakes", []),
+                "strengths": data.get("strengths", []),
+            }
+        except Exception:
+            pass
+
+    # Фолбэк, если LLM недоступен или ответ некорректен
+    return {
+        "correct": False,
+        "final_answer": "н/д",
+        "score": 50,
+        "feedback": (
+            "Пока не могу проверить решение автоматически."
+            " Попробуй самостоятельно оценить ответ или повтори попытку позже."
+        ),
+        "mistakes": ["Проверка выполнена в офлайн-режиме"],
+        "strengths": [],
+    }
+
+
+async def generate_meme_text(score: int, task_text: str, difficulty: str) -> str:
+    if client:
+        prompt = MEME_GENERATION_PROMPT.format(
+            score=score,
+            task_type="текстовая задача" if len(task_text) > 40 else "быстрый пример",
+            difficulty=difficulty,
+        )
+        messages = [{
+            "role": "user",
+            "content": [{"type": "text", "text": prompt}]
+        }]
+        try:
+            return await call_claude(messages, "Создай короткий и позитивный мем.")
+        except Exception:
+            pass
+
+    # Фолбэк без LLM
+    if score >= 80:
+        return "Gigachad момент! Математика сама решается, когда ты рядом."
+    if score >= 60:
+        return "W-победа! Еще пару шагов — и станешь легендой алгебры."
+    if score >= 40:
+        return "Мы это засчитаем. Маленькие победы тоже считаются!"
+    return "Это не провал, это монтаж тренировки. В следующий раз точно разнесешь!"
+
+
+def register_handlers(application: Application) -> None:
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("reset", reset_command))
+    application.add_handler(CommandHandler("submit", submit_command))
+    application.add_handler(CommandHandler("stats", stats_command))
+    application.add_handler(CommandHandler("hint", hint_command))
+    application.add_handler(CommandHandler("keyboard", keyboard_command))
+
+    application.add_handler(CallbackQueryHandler(button_handler))
+    application.add_handler(MessageHandler(filters.PHOTO, handle_photo))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+
+
+def create_application() -> Application:
+    if not TELEGRAM_TOKEN:
+        raise RuntimeError("TELEGRAM_TOKEN is not configured")
+
+    application = Application.builder().token(TELEGRAM_TOKEN).build()
+    register_handlers(application)
+    return application
+
+
+def main():
+    application = create_application()
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- guard Anthropic client creation and reuse a configurable default model
- implement async helpers for tutoring replies, verification, meme generation, and statistics formatting with offline fallbacks
- wire up command handlers and application factory so the Telegram bot can reset, submit, and run polling again

## Testing
- python -m py_compile bot.py

------
https://chatgpt.com/codex/tasks/task_e_68e506917a94832795a320ea9828b6a0